### PR TITLE
Made it possible to render timline to highest year in events.

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@ h1{
 		$title: document.getElementById('title'),
 		$el: document.getElementById('life'),
 		yearLength: 120, // 120px per year
+		finalYear: new Date().getFullYear(),
 		start: function(){
 			life.loadConfig(function(config){
 				if (config.yearLength) life.yearLength = config.yearLength;
@@ -188,7 +189,20 @@ h1{
 				data.endDate = now.getDate();
 			}
 			data.title = time;
+			life.updateFinalYear(data.startYear, data.endYear);
+			
 			return data;
+		},
+		updateFinalYear: function(startYear, endYear){
+			if (endYear && endYear > life.finalYear) {
+				life.finalYear = endYear;
+			}
+			else if (startYear && startYear > life.finalYear) {
+				life.finalYear = startYear;
+			}
+			else {
+				// noo need to check and update
+			}
 		},
 		firstYear: null,
 		renderEvent: function(d){
@@ -239,13 +253,13 @@ h1{
 			life.$title.innerHTML = title;
 
 			var firstYear = life.firstYear = data[0].time.startYear;
-			var nowYear = new Date().getFullYear();
+			var finalYear = life.finalYear + 1; // add one for better rendering
 			var dayLength = life.yearLength/12/30;
 
 			var html = '';
 			var days = 0;
 
-			for (var y=firstYear, age = 0; y<=nowYear+1; y++, age++){
+			for (var y=firstYear, age = 0; y<=finalYear; y++, age++){
 				html += '<section class="year" style="left: ' + (days*dayLength) + 'px">' +
 					y + ' (' + age + ')' +
 					'</section>';


### PR DESCRIPTION
When parsing the events, the `parseTime` function now also checks
to see if the event was higher than the current final year. The
final year begins with the current year and any future events will
increase it.

This way you can add future events without having to do any manual
configuration, like updating `config.json`, and not have to worry about
strange rendering.

I'm not entirely comfortable with `parseTime` having side-effects but 
you may be ok with it. I couldn't think of a simpler way to do it. A demo
of the fix working can be seen at http://mattcan.github.io/life/ with code at
0e11598

This is meant to fix issue #16.
