### PR TITLE
Allow for tags at the end of an event with square brackets, e.g. [job]

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,10 +144,13 @@ h1{
 			list.forEach(function(l){
 				var matches = l.match(/\-\s+([\d\/\-\~]+)\s(.*)/i);
 				var time = matches[1];
-				var text = matches[2];
+				var tagindex = matches[2].indexOf('[');
+				var text = matches[2].substring(0, tagindex);
+				var tag = (tagindex > -1 ? matches[2].substring(tagindex).replace(/[\[|\]]/gi, '') : '');
 				data.push({
 					time: life.parseTime(time),
-					text: text
+					text: text,
+					tag: tag
 				});
 			});
 			return data;
@@ -230,7 +233,7 @@ h1{
 				}
 			}
 
-			return '<div class="event" style="margin-left: ' + offset.toFixed(2) + 'px"><div class="time" style="width: ' + width.toFixed(2) + 'px"></div><b>' + d.time.title + '</b> ' + d.text + '&nbsp;&nbsp;</div>';
+			return '<div class="event" style="margin-left: ' + offset.toFixed(2) + 'px"><div class="time ' + d.tag + '" style="width: ' + width.toFixed(2) + 'px"></div><b>' + d.time.title + '</b> ' + d.text + '&nbsp;&nbsp;</div>';
 			return '';
 		},
 		render: function(title, data){


### PR DESCRIPTION
This simple modification will allow for optional tags by adding it at the end of your event, like so:

``` md
@USERNAME' life
===============

- 24/02/1955 Born
- ~1968 Summer job [job]
- 03/1976 Built a computer
- 01/04/1976 Started a company
- 04/1976-2011 Whole bunch of interesting events [something]
```

These can then be easily styled with a custom css:

``` css
#life .event .time.job {
    border: 4px solid #3498db;
}
```

To see this working, I have it running myself currently and works like a charm:
http://timeline.owens.nl/
